### PR TITLE
Corrected NullReferenceException and expanded testing

### DIFF
--- a/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreBreakdanceTestBase.cs
+++ b/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreBreakdanceTestBase.cs
@@ -53,7 +53,7 @@ namespace CloudNimble.Breakdance.AspNetCore
         public AspNetCoreBreakdanceTestBase()
         {
             // configure the TestHostBuilder in the base class to create a WebHost
-            TestHostBuilder = new HostBuilder()
+            TestHostBuilder
                 .ConfigureWebHost(builder =>
                 {
                     builder.UseTestServer()
@@ -145,6 +145,7 @@ namespace CloudNimble.Breakdance.AspNetCore
         {
             if (TestServer == null)
             {
+                EnsureTestHost();
                 TestHost.Start();
                 TestServer = TestHost.GetTestServer();
                 TestClient = TestServer.CreateClient();

--- a/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreBreakdanceTestBase.cs
+++ b/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreBreakdanceTestBase.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace CloudNimble.Breakdance.AspNetCore
 {
@@ -103,7 +104,7 @@ namespace CloudNimble.Breakdance.AspNetCore
         public override void AssemblySetup()
         {
             base.AssemblySetup();
-            EnsureTestServer();
+            EnsureTestServer().GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -117,7 +118,7 @@ namespace CloudNimble.Breakdance.AspNetCore
         public override void TestSetup()
         {
             base.TestSetup();
-            EnsureTestServer();
+            EnsureTestServer().GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -141,12 +142,12 @@ namespace CloudNimble.Breakdance.AspNetCore
         /// <summary>
         /// Properly instantiates the <see cref="TestServer"/> and if <see cref="RegisterServices"/> is not null, properly registers additional services with the context.
         /// </summary>
-        internal void EnsureTestServer()
+        internal async Task EnsureTestServer()
         {
             if (TestServer == null)
             {
                 EnsureTestHost();
-                TestHost.Start();
+                await TestHost.StartAsync().ConfigureAwait(false);
                 TestServer = TestHost.GetTestServer();
                 TestClient = TestServer.CreateClient();
             }

--- a/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreTestHelpers.cs
+++ b/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreTestHelpers.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Threading.Tasks;
 
 namespace CloudNimble.Breakdance.AspNetCore
 {
@@ -14,10 +15,10 @@ namespace CloudNimble.Breakdance.AspNetCore
         /// <summary>
         /// Gets a new <see cref="TestServer" /> with default services.
         /// </summary>
-        public static TestServer GetTestableHttpServer()
+        public static async Task<TestServer> GetTestableHttpServer()
         {
             var testBase = new AspNetCoreBreakdanceTestBase();
-            testBase.EnsureTestServer();
+            await testBase.EnsureTestServer().ConfigureAwait(false);
             return testBase.TestServer;
         }
 
@@ -26,11 +27,13 @@ namespace CloudNimble.Breakdance.AspNetCore
         /// </summary>
         /// <param name="registration">Delegate for customizing the <see cref="IServiceCollection"/> of services available to the host.</param>
         /// <returns></returns>
-        public static TestServer GetTestableHttpServer(Action<IServiceCollection> registration)
+        public static async Task<TestServer> GetTestableHttpServer(Action<IServiceCollection> registration)
         {
-            var testBase = new AspNetCoreBreakdanceTestBase();
-            testBase.RegisterServices = registration;
-            testBase.EnsureTestServer();
+            var testBase = new AspNetCoreBreakdanceTestBase
+            {
+                RegisterServices = registration
+            };
+            await testBase.EnsureTestServer().ConfigureAwait(false);
             return testBase.TestServer;
         }
 
@@ -40,12 +43,14 @@ namespace CloudNimble.Breakdance.AspNetCore
         /// <param name="registration">Delegate for customizing the <see cref="IServiceCollection"/> of services available to the host.</param>
         /// <param name="builder">Delegate for customizing the <see cref="IApplicationBuilder"></see> used to configure the host.</param>
         /// <returns></returns>
-        public static TestServer GetTestableHttpServer(Action<IServiceCollection> registration, Action<IApplicationBuilder> builder)
+        public static async Task<TestServer> GetTestableHttpServer(Action<IServiceCollection> registration, Action<IApplicationBuilder> builder)
         {
-            var testBase = new AspNetCoreBreakdanceTestBase();
-            testBase.RegisterServices = registration;
-            testBase.ConfigureHost = builder;
-            testBase.EnsureTestServer();
+            var testBase = new AspNetCoreBreakdanceTestBase
+            {
+                RegisterServices = registration,
+                ConfigureHost = builder
+            };
+            await testBase.EnsureTestServer().ConfigureAwait(false);
             return testBase.TestServer;
         }
 

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBaseTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBaseTests.cs
@@ -13,7 +13,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Breakdance.Tests.AspNetCore
+namespace CloudNimble.Breakdance.Tests.AspNetCore
 {
 
     /// <summary>
@@ -95,9 +95,5 @@ namespace Breakdance.Tests.AspNetCore
             content.Should().Be("Hello from the dummy middleware!");
         }
 
-    }
-
-    public class DummyService
-    {
     }
 }

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBase_CoreTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBase_CoreTests.cs
@@ -94,8 +94,4 @@ namespace CloudNimble.Breakdance.Tests.AspNetCore
         }
 
     }
-
-    public class DummyService
-    {
-    }
 }

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreTestHelperTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreTestHelperTests.cs
@@ -1,0 +1,90 @@
+﻿using CloudNimble.Breakdance.AspNetCore;
+using FluentAssertions;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CloudNimble.Breakdance.Tests.AspNetCore
+{
+
+    /// <summary>
+    /// Tests the static methods provided in <see cref="AspNetCoreTestHelpers"/>.
+    /// </summary>
+    [TestClass]
+    public class AspNetCoreTestHelperTests
+    {
+        /// <summary>
+        /// Tests that the static method properly creates a <see cref="TestServer"/> with expected defaults in its <see cref="IServiceCollection"/>.
+        /// </summary>
+        [TestMethod]
+        public void CanGetTestableHttpServer_WithoutConfiguration()
+        {
+            var server = AspNetCoreTestHelpers.GetTestableHttpServer();
+            server.Should().NotBeNull();
+            server.Services.GetAllServiceDescriptors().Should().HaveCount(43);
+        }
+
+        /// <summary>
+        /// Tests that the static method properly creates a <see cref="TestServer"/> that can generate an <see cref="HttpClient"/>.
+        /// </summary>
+        [TestMethod]
+        public void CanGetTestableHttpClient_FromServer()
+        {
+            var server = AspNetCoreTestHelpers.GetTestableHttpServer();
+            var client = server.CreateClient();
+            client.Should().NotBeNull();
+        }
+
+        /// <summary>
+        /// Tests that the static method can properly pass configuration delegates to the <see cref="IHostBuilder"/>.
+        /// </summary>
+        [TestMethod]
+        public void CanGetTestableHttpServer_WithFullConfiguration()
+        {
+            var server = AspNetCoreTestHelpers.GetTestableHttpServer(
+                services => {
+                    services.AddScoped<DummyService>();
+                },
+                builder =>
+                {
+                    builder.ServerFeatures.Set(new EmptyFeature());
+                });
+
+            server.Services.GetAllServiceDescriptors().Should().HaveCount(44);
+            server.Features.Should().Contain(c => c.Key.Name == nameof(EmptyFeature));
+        }
+
+        /// <summary>
+        /// Tests that the static method correctly configures and starts up the <see cref="TestServer"/>.
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task CanGetTestableHttpServer_WithFunctioningClient()
+        {
+            var server = AspNetCoreTestHelpers.GetTestableHttpServer(
+                services => {
+                    services.AddScoped<DummyService>();
+                },
+                builder =>
+                {
+                    builder.ServerFeatures.Set(new EmptyFeature());
+                });
+
+            server.Services.GetAllServiceDescriptors().Should().HaveCount(44);
+            server.Features.Should().Contain(c => c.Key.Name == nameof(EmptyFeature));
+
+            var client = server.CreateClient();
+            var response = await client.GetAsync("/");
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+
+    }
+}

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/DummyService.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/DummyService.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CloudNimble.Breakdance.Tests.AspNetCore
+{
+
+    /// <summary>
+    /// An empty class for testing dependency injection
+    /// </summary>
+    public class DummyService
+    {
+    }
+}

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/EmptyFeature.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/EmptyFeature.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CloudNimble.Breakdance.Tests.AspNetCore
+{
+    public class EmptyFeature
+    {
+    }
+}


### PR DESCRIPTION
The static method AspNeCoreTestHelpers.GetTestableHttpServer() was throwing a NulLReferenceException because the Host was not being BUILT before it was STARTED.  I correct this by adding the call to EnsureTestHost() from the derived class' EnsureTestServer().

I also added some more unit tests for the static method overloads since the existing tests were using the class in a slightly different way.