### PR TITLE
AspNetCore Breakdance test base refactor

### DIFF
--- a/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreBreakdanceTestBase.cs
+++ b/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreBreakdanceTestBase.cs
@@ -1,12 +1,9 @@
 ﻿using CloudNimble.Breakdance.Assemblies;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using System;
 using System.Collections.Generic;
 

--- a/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreTestHelpers.cs
+++ b/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreTestHelpers.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 
 namespace CloudNimble.Breakdance.AspNetCore
 {
@@ -45,12 +46,22 @@ namespace CloudNimble.Breakdance.AspNetCore
         /// <returns></returns>
         public static TestServer GetTestableHttpServer(Action<IServiceCollection> registration, Action<IApplicationBuilder> builder, Action<IConfigurationBuilder> configuration)
         {
-            var testBase = new AspNetCoreBreakdanceTestBase
+            var testBase = new AspNetCoreBreakdanceTestBase();
+            if (registration is not null)
             {
-                RegisterServices = registration,
-                ConfigureHost = builder,
-                BuildConfiguration = configuration
-            };
+                testBase.TestHostBuilder.ConfigureServices(services => registration.Invoke(services));
+            }
+
+            if (builder is not null)
+            {
+                testBase.TestHostBuilder.Configure(appBuilder => builder.Invoke(appBuilder));
+            }
+
+            if (configuration is not null)
+            {
+                testBase.TestHostBuilder.ConfigureAppConfiguration(appConfig => configuration.Invoke(appConfig));
+            }
+
             testBase.EnsureTestServer();
             return testBase.TestServer;
         }

--- a/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreTestHelpers.cs
+++ b/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreTestHelpers.cs
@@ -1,10 +1,9 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting;
 
 namespace CloudNimble.Breakdance.AspNetCore
 {

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBaseTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBaseTests.cs
@@ -12,6 +12,8 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using System.Collections;
 
 namespace CloudNimble.Breakdance.Tests.AspNetCore
 {
@@ -28,16 +30,16 @@ namespace CloudNimble.Breakdance.Tests.AspNetCore
         [TestInitialize]
         public void Setup()
         {
-            RegisterServices = services =>
+            TestHostBuilder.ConfigureServices(services =>
             {
                 services.AddScoped<FakeService>();
 
                 services.AddMvcCore(setup => setup.EnableEndpointRouting = false)
                     .AddApplicationPart(typeof(HomeController).Assembly);
 
-            };
+            });
 
-            ConfigureHost = builder =>
+            TestHostBuilder.Configure(builder =>
             {
                 builder.UseMvcWithDefaultRoute();
                 builder.UseResponseCaching();
@@ -55,7 +57,7 @@ namespace CloudNimble.Breakdance.Tests.AspNetCore
 
                 });
 
-            };
+            });
 
             TestSetup();
         }
@@ -72,10 +74,9 @@ namespace CloudNimble.Breakdance.Tests.AspNetCore
         public void BlazorBreakdanceTestBase_Setup_CreatesTestServer_WithExpectedServices()
         {
             TestServer.Should().NotBeNull();
-            RegisterServices.Should().NotBeNull();
-            //TestServer.Services.GetAllServiceDescriptors().Should().HaveCount(28);
             GetService<IConfiguration>().Should().NotBeNull();
             GetService<FakeService>().Should().NotBeNull();
+            TestServer.Features.As<IEnumerable>().Should().BeEmpty();
         }
 
         /// <summary>

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBase_CoreTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBase_CoreTests.cs
@@ -6,90 +6,126 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections;
 
 namespace CloudNimble.Breakdance.Tests.AspNetCore
 {
 
     /// <summary>
-    /// Tests the functionality of <see cref="AspNetCoreBreakdanceTestBase"/> directly.
+    /// Tests the functionality of <see cref="AspNetCoreBreakdanceTestBase"/> when the object is used directly instead of being used as a base class.
     /// </summary>
     [TestClass]
     public class AspNetCoreBreakdanceTestBase_CoreTests
     {
 
         /// <summary>
-        /// Tests wether or not a <see cref="TestServer"/> is created on setup.
+        /// Tests that a <see cref="TestServer"/> is created when EnsureTestServer() is called.
         /// </summary>
         [TestMethod]
-        public void AspNetCoreBreakdanceTestBase_Setup_CreatesTestServer_NoSetup()
+        public void AspNetCoreBreakdanceTestBase_EnsureTestServer_CreatesDefaultConfig()
         {
             var testBase = new AspNetCoreBreakdanceTestBase();
-
             testBase.TestServer.Should().BeNull();
-            testBase.RegisterServices.Should().BeNull();
-            testBase.ConfigureHost.Should().BeNull();
             testBase.GetService<IConfiguration>().Should().BeNull();
 
-            testBase.TestSetup();
+            testBase.EnsureTestServer();
 
-            testBase.TestServer.Should().NotBeNull();
-            testBase.RegisterServices.Should().BeNull();
-            testBase.ConfigureHost.Should().BeNull();
-            //testBase.TestServer.Services.GetAllServiceDescriptors().Should().HaveCount(27);
             testBase.GetService<IConfiguration>().Should().NotBeNull();
+            testBase.TestServer.Features.As<IEnumerable>().Should().BeEmpty();
         }
 
         /// <summary>
         /// Tests that DI works property when configuring services for <see cref="TestServer"/>.
         /// </summary>
         [TestMethod]
-        public void AspNetCoreBreakdanceTestBase_Setup_CreatesTestServer_WithRegisteredServices()
+        public void AspNetCoreBreakdanceTestBase_TestServer_CanRegisterServices()
         {
             var testBase = new AspNetCoreBreakdanceTestBase();
-
             testBase.TestServer.Should().BeNull();
-            testBase.RegisterServices.Should().BeNull();
-            testBase.ConfigureHost.Should().BeNull();
+            testBase.GetService<IConfiguration>().Should().BeNull();
+            testBase.GetService<FakeService>().Should().BeNull();
 
-            testBase.RegisterServices = services => {
+            testBase.TestHostBuilder.ConfigureServices(services => {
                 services.AddScoped<FakeService>();
-            };
-            testBase.TestSetup();
+            });
+
+            testBase.EnsureTestServer();
 
             testBase.TestServer.Should().NotBeNull();
-            testBase.RegisterServices.Should().NotBeNull();
-            testBase.ConfigureHost.Should().BeNull();
-            //testBase.TestServer.Services.GetAllServiceDescriptors().Should().HaveCount(28);
             testBase.GetService<IConfiguration>().Should().NotBeNull();
             testBase.GetService<FakeService>().Should().NotBeNull();
         }
 
         /// <summary>
-        /// Tests that both service configuration and host building delegates function properly.
+        /// Tests that the <see cref="TestServer"/> has the expected services.
         /// </summary>
         [TestMethod]
-        public void AspNetCoreBreakdanceTestBase_Setup_CreatesTestServer_WithAppBuilder()
+        public void AspNetCoreBreakdanceTestBase_AddMinimalMvc_HasExpectedServices()
         {
             var testBase = new AspNetCoreBreakdanceTestBase();
-
             testBase.TestServer.Should().BeNull();
-            testBase.RegisterServices.Should().BeNull();
-            testBase.ConfigureHost.Should().BeNull();
 
-            testBase.ConfigureHost = builder =>
-            {
-                builder.ServerFeatures.Set<IServerAddressesFeature>(new ServerAddressesFeature());
-            };
-
-            testBase.TestSetup();
+            testBase.AddMinimalMvc(options => options.EnableEndpointRouting = false);
+            testBase.EnsureTestServer();
 
             testBase.TestServer.Should().NotBeNull();
-            testBase.RegisterServices.Should().BeNull();
-            testBase.ConfigureHost.Should().NotBeNull();
-
-            //testBase.TestServer.Services.GetAllServiceDescriptors().Should().HaveCount(28);
             testBase.GetService<IConfiguration>().Should().NotBeNull();
-            testBase.TestServer.Features.Get<IServerAddressesFeature>().Should().NotBeNull();
+
+            // JHC TODO: add asserts here using testBase.GetService<T> to ensure that the expected services were registered on the host
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="TestServer"/> has the expected services.
+        /// </summary>
+        [TestMethod]
+        public void AspNetCoreBreakdanceTestBase_AddApis_HasExpectedServices()
+        {
+            var testBase = new AspNetCoreBreakdanceTestBase();
+            testBase.TestServer.Should().BeNull();
+
+            testBase.AddApis(options => options.EnableEndpointRouting = false);
+            testBase.EnsureTestServer();
+
+            testBase.TestServer.Should().NotBeNull();
+            testBase.GetService<IConfiguration>().Should().NotBeNull();
+
+            // JHC TODO: add asserts here using testBase.GetService<T> to ensure that the expected services were registered on the host
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="TestServer"/> has the expected services.
+        /// </summary>
+        [TestMethod]
+        public void AspNetCoreBreakdanceTestBase_AddViews_HasExpectedServices()
+        {
+            var testBase = new AspNetCoreBreakdanceTestBase();
+            testBase.TestServer.Should().BeNull();
+
+            testBase.AddViews(options => options.EnableEndpointRouting = false);
+            testBase.EnsureTestServer();
+
+            testBase.TestServer.Should().NotBeNull();
+            testBase.GetService<IConfiguration>().Should().NotBeNull();
+
+            // JHC TODO: add asserts here using testBase.GetService<T> to ensure that the expected services were registered on the host
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="TestServer"/> has the expected services.
+        /// </summary>
+        [TestMethod]
+        public void AspNetCoreBreakdanceTestBase_AddRazorPages_HasExpectedServices()
+        {
+            var testBase = new AspNetCoreBreakdanceTestBase();
+            testBase.TestServer.Should().BeNull();
+
+            testBase.AddRazorPages();
+            testBase.EnsureTestServer();
+
+            testBase.TestServer.Should().NotBeNull();
+            testBase.GetService<IConfiguration>().Should().NotBeNull();
+
+            // JHC TODO: add asserts here using testBase.GetService<T> to ensure that the expected services were registered on the host
         }
 
     }

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBase_CoreTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBase_CoreTests.cs
@@ -1,7 +1,6 @@
 using CloudNimble.Breakdance.AspNetCore;
 using CloudNimble.Breakdance.Tests.AspNetCore.Fakes;
 using FluentAssertions;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Removed Action<> delegates completely.  The TestHostBuilder can be used directly to register services, configuration, features.
Added new methods to configure common services in the host prior to startup.
Added additional unit tests.