### PR TITLE
Add HttpResponseMessageExtensions to Breakdance.AspNetCore.

### DIFF
--- a/src/CloudNimble.Breakdance.AspNetCore/Breakdance.AspNetCore.csproj
+++ b/src/CloudNimble.Breakdance.AspNetCore/Breakdance.AspNetCore.csproj
@@ -31,10 +31,12 @@
   <ItemGroup>
     <Compile Include="..\CloudNimble.Breakdance.WebApi\ODataConstants.cs" Link="ODataConstants.cs" />
     <Compile Include="..\CloudNimble.Breakdance.WebApi\WebApiConstants.cs" Link="WebApiConstants.cs" />
+    <Compile Include="..\CloudNimble.Breakdance.WebApi\Extensions\HttpResponseMessageExtensions.cs" Link="Extensions\HttpResponseMessageExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBase_CoreTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreBreakdanceTestBase_CoreTests.cs
@@ -50,6 +50,7 @@ namespace CloudNimble.Breakdance.Tests.AspNetCore
                 services.AddScoped<FakeService>();
             });
 
+            testBase.AddMinimalMvc();
             testBase.EnsureTestServer();
 
             testBase.TestServer.Should().NotBeNull();

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreTestHelperTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/AspNetCoreTestHelperTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -24,11 +25,10 @@ namespace CloudNimble.Breakdance.Tests.AspNetCore
         /// Tests that the static method properly creates a <see cref="TestServer"/>.
         /// </summary>
         [TestMethod]
-        public void GetTestableHttpServer_WithoutConfiguration_CreatesServer()
+        public void GetTestableHttpServer_WithoutConfiguration_ThrowsException()
         {
-            var server = AspNetCoreTestHelpers.GetTestableHttpServer();
-            server.Should().NotBeNull();
-            //server.Services.GetAllServiceDescriptors().Should().HaveCount(43);
+            Action configureService = () => { var server = AspNetCoreTestHelpers.GetTestableHttpServer(); };
+            configureService.Should().Throw<InvalidOperationException>();
         }
 
         /// <summary>


### PR DESCRIPTION
Test cleanup plus addition of HttpResponseMessageExtensions that are needed for ResTIER testing.  These extensions are present in Breakdance.WebApi but not Breakdance.AspNetCore.