### PR TITLE
Breakdance.Tools update

### DIFF
--- a/src/CloudNimble.Breakdance.AspNetCore/Breakdance.AspNetCore.csproj
+++ b/src/CloudNimble.Breakdance.AspNetCore/Breakdance.AspNetCore.csproj
@@ -31,13 +31,10 @@
   <ItemGroup>
     <Compile Include="..\CloudNimble.Breakdance.WebApi\ODataConstants.cs" Link="ODataConstants.cs" />
     <Compile Include="..\CloudNimble.Breakdance.WebApi\WebApiConstants.cs" Link="WebApiConstants.cs" />
-    <Compile Include="..\CloudNimble.Breakdance.WebApi\HttpClientHelpers.cs" Link="HttpClientHelpers.cs" />
-    <Compile Include="..\CloudNimble.Breakdance.WebApi\Extensions\HttpResponseMessageExtensions.cs" Link="Extensions\HttpResponseMessageExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CloudNimble.Breakdance.AspNetCore/Breakdance.AspNetCore.csproj
+++ b/src/CloudNimble.Breakdance.AspNetCore/Breakdance.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>CloudNimble.Breakdance.AspNetCore</RootNamespace>
     <AssemblyName>CloudNimble.Breakdance.AspNetCore</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
@@ -34,7 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.7" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.16" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CloudNimble.Breakdance.AspNetCore/Breakdance.AspNetCore.csproj
+++ b/src/CloudNimble.Breakdance.AspNetCore/Breakdance.AspNetCore.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <Compile Include="..\CloudNimble.Breakdance.WebApi\ODataConstants.cs" Link="ODataConstants.cs" />
     <Compile Include="..\CloudNimble.Breakdance.WebApi\WebApiConstants.cs" Link="WebApiConstants.cs" />
+    <Compile Include="..\CloudNimble.Breakdance.WebApi\HttpClientHelpers.cs" Link="HttpClientHelpers.cs" />
     <Compile Include="..\CloudNimble.Breakdance.WebApi\Extensions\HttpResponseMessageExtensions.cs" Link="Extensions\HttpResponseMessageExtensions.cs" />
   </ItemGroup>
 

--- a/src/CloudNimble.Breakdance.AspNetCore/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/CloudNimble.Breakdance.AspNetCore/Extensions/HttpResponseMessageExtensions.cs
@@ -1,0 +1,105 @@
+﻿using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class HttpResponseMessageExtensions
+    {
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        public static async Task<(T Response, string ErrorContent)> DeserializeResponseAsync<T>(this HttpResponseMessage message)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (!message.IsSuccessStatusCode)
+            {
+                return (default, await message.Content.ReadAsStringAsync().ConfigureAwait(false));
+            }
+            var content = await message.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return (JsonSerializer.Deserialize<T>(content), null);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="message"></param>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        public static async Task<(T Response, string ErrorContent)> DeserializeResponseAsync<T>(this HttpResponseMessage message, JsonSerializerOptions settings)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (!message.IsSuccessStatusCode)
+            {
+                return (default, await message.Content.ReadAsStringAsync().ConfigureAwait(false));
+            }
+            var content = await message.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return (JsonSerializer.Deserialize<T>(content, settings), null);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TResponse"></typeparam>
+        /// <typeparam name="TError"></typeparam>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        public static async Task<(TResponse Response, TError ErrorContent)> DeserializeResponseAsync<TResponse, TError>(this HttpResponseMessage message)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            var content = await message.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            if (!message.IsSuccessStatusCode)
+            {
+                return (default, JsonSerializer.Deserialize<TError>(content));
+            }
+            return (JsonSerializer.Deserialize<TResponse>(content), default);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TResponse"></typeparam>
+        /// <typeparam name="TError"></typeparam>
+        /// <param name="message"></param>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        public static async Task<(TResponse Response, TError ErrorContent)> DeserializeResponseAsync<TResponse, TError>(this HttpResponseMessage message, JsonSerializerOptions settings)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            var content = await message.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            if (!message.IsSuccessStatusCode)
+            {
+                return (default, JsonSerializer.Deserialize<TError>(content));
+            }
+            return (JsonSerializer.Deserialize<TResponse>(content, settings), default);
+        }
+
+    }
+
+}

--- a/src/CloudNimble.Breakdance.AspNetCore/HttpClientHelpers.cs
+++ b/src/CloudNimble.Breakdance.AspNetCore/HttpClientHelpers.cs
@@ -1,31 +1,35 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace CloudNimble.Breakdance.AspNetCore
 {
 
     /// <summary>
-    /// 
+    /// Helper methods for dealing with <see cref="HttpRequestMessage"/>.
     /// </summary>
     public static class HttpClientHelpers
     {
 
         /// <summary>
-        /// 
+        /// Sets up serialization options
         /// </summary>
+        /// <remarks>Slightly different implementation between core versions.</remarks>
         private static readonly JsonSerializerOptions JsonSerializerDefaults = new()
         {
+            // ignore all null-value properties when serializing or deserializing (different implementation in net3.1 vs net5+)
+#if NETCOREAPP3_1
+            IgnoreNullValues = true,
+#endif
+#if NET5_0_OR_GREATER
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+#endif
         };
 
-        #region Public Methods
+#region Public Methods
 
         /// <summary>
         /// Gets an <see cref="HttpRequestMessage"/> instance properly configured to be used to make test requests.
@@ -60,7 +64,7 @@ namespace CloudNimble.Breakdance.AspNetCore
             return request;
         }
 
-        #endregion
+#endregion
 
     }
 

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/Breakdance.Tests.AspNetCore.csproj
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/Breakdance.Tests.AspNetCore.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>CloudNimble.Breakdance.Tests.AspNetCore</AssemblyName>
+    <RootNamespace>CloudNimble.Breakdance.Tests.AspNetCore</RootNamespace>
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore/HttpClientHelpersTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore/HttpClientHelpersTests.cs
@@ -3,7 +3,7 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Net.Http;
 
-namespace Breakdance.Tests.AspNetCore
+namespace CloudNimble.Breakdance.Tests.AspNetCore
 {
 
     [TestClass]

--- a/src/CloudNimble.Breakdance.Tests.Assemblies/Breakdance.Tests.Assemblies.csproj
+++ b/src/CloudNimble.Breakdance.Tests.Assemblies/Breakdance.Tests.Assemblies.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>CloudNimble.Breakdance.Tests.Assemblies</AssemblyName>
+    <RootNamespace>CloudNimble.Breakdance.Tests.Assemblies</RootNamespace>
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\.runsettings</RunSettingsFilePath>

--- a/src/CloudNimble.Breakdance.Tests.Blazor/BlazorBreakdanceTestBaseTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.Blazor/BlazorBreakdanceTestBaseTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Breakdance.Tests.Blazor
+namespace CloudNimble.Breakdance.Tests.Blazor
 {
 
     /// <summary>

--- a/src/CloudNimble.Breakdance.Tests.Blazor/BlazorBreakdanceTestBase_CoreTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.Blazor/BlazorBreakdanceTestBase_CoreTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Breakdance.Tests.Blazor
+namespace CloudNimble.Breakdance.Tests.Blazor
 {
 
     /// <summary>

--- a/src/CloudNimble.Breakdance.Tests.Blazor/Breakdance.Tests.Blazor.csproj
+++ b/src/CloudNimble.Breakdance.Tests.Blazor/Breakdance.Tests.Blazor.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>CloudNimble.Breakdance.Tests.Blazor</AssemblyName>
+    <RootNamespace>CloudNimble.Breakdance.Tests.Blazor</RootNamespace>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/CloudNimble.Breakdance.Tests.WebApi/Breakdance.Tests.WebApi.csproj
+++ b/src/CloudNimble.Breakdance.Tests.WebApi/Breakdance.Tests.WebApi.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>CloudNimble.Breakdance.Tests.WebApi</AssemblyName>
+    <RootNamespace>CloudNimble.Breakdance.Tests.WebApi</RootNamespace>
     <TargetFrameworks>net472;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/CloudNimble.Breakdance.Tests.WebApi/HttpResponseMessageExtensionTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.WebApi/HttpResponseMessageExtensionTests.cs
@@ -5,7 +5,7 @@ using System.Dynamic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace Breakdance.Tests.WebApi
+namespace CloudNimble.Breakdance.Tests.WebApi
 {
 
     /// <summary>

--- a/src/CloudNimble.Breakdance.Tests.WebApi/WebApiTestHelperTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.WebApi/WebApiTestHelperTests.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Breakdance.Tests.WebApi
+namespace CloudNimble.Breakdance.Tests.WebApi
 {
 
     /// <summary>

--- a/src/CloudNimble.Breakdance.Tools/Breakdance.Tools.csproj
+++ b/src/CloudNimble.Breakdance.Tools/Breakdance.Tools.csproj
@@ -14,10 +14,19 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="5.0.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\CloudNimble.Breakdance.Assemblies\Breakdance.Assemblies.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost">
+      <Version>5.0.7</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/CloudNimble.Breakdance.Tools/Breakdance.Tools.csproj
+++ b/src/CloudNimble.Breakdance.Tools/Breakdance.Tools.csproj
@@ -14,19 +14,10 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="5.0.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\CloudNimble.Breakdance.Assemblies\Breakdance.Assemblies.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost">
-      <Version>5.0.7</Version>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/CloudNimble.Breakdance.Tools/Program.cs
+++ b/src/CloudNimble.Breakdance.Tools/Program.cs
@@ -64,41 +64,35 @@ namespace CloudNimble.Breakdance.Tools
         {
             ColorConsole.WriteEmbeddedColorLine($"Looking for Tests in path [cyan]{path}[/cyan]...", ConsoleColor.Yellow);
 
+            var projects = Directory.GetDirectories(path);
             var tests = new List<string>();
+            var isInProjectFolder = projects.Any(c => c.Contains("obj"));
 
-            // using the specified path, locate any test project folders
-            var projects = Directory.GetDirectories(path, ".test*");
-            //RWM: First find the test folders.
-            tests = projects.Where(c => !string.IsNullOrWhiteSpace(project) ? c.Contains(project) : c.ToLower().Contains(project ?? ".test")).OrderBy(c => c.Length).ToList();
-
-            if (!tests.Any())
+            if (isInProjectFolder)
             {
-                // determine if the current folder is a test project
-                var folderName = Path.GetFileName(path);
-
-                if (folderName.ToLower().Contains(".test"))
-                {
-                    tests.Add(path);
-                    ColorConsole.WriteSuccess("Found a Test project at the root of the specified path.");
-                    ColorConsole.WriteInfo(folderName);
-                    ColorConsole.WriteLine("");
-                }
-                else
-                {
-                    ColorConsole.WriteError($"No tests found.");
-                    return;
-                }
+                //RWM: Optionally test if the current folder has .test in it and complain if it doesn't.
+                ColorConsole.WriteWarning($"'obj' folder found in child folders. Assuming {path} is a test project.");
+                tests.Add(path);
             }
             else
             {
-                ColorConsole.WriteSuccess("The following Test projects were found:");
-                foreach (var test in tests)
-                {
-                    ColorConsole.WriteInfo($"{test}");
-                }
-                ColorConsole.WriteLine("");
+                tests = projects
+                          .Where(c => !string.IsNullOrWhiteSpace(project) ? c.Contains(project) : c.ToLower().Contains(project ?? ".test"))
+                          .OrderBy(c => c.Length).ToList();
             }
 
+            if (!tests.Any())
+            {
+                ColorConsole.WriteError($"No tests found.");
+                return;
+            }
+
+            ColorConsole.WriteSuccess("The following Test projects were found:");
+            foreach (var test in tests)
+            {
+                ColorConsole.WriteInfo($"{test}");
+            }
+            ColorConsole.WriteLine("");
 
             //RWM: Then find the tests using Breakdance
             foreach (var testPath in tests)

--- a/src/CloudNimble.Breakdance.WebApi/HttpClientHelpers.cs
+++ b/src/CloudNimble.Breakdance.WebApi/HttpClientHelpers.cs
@@ -4,7 +4,11 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 
+#if NET5_0_OR_GREATER
+namespace CloudNimble.Breakdance.AspNetCore
+#else
 namespace CloudNimble.Breakdance.WebApi
+#endif
 {
 
     /// <summary>

--- a/src/CloudNimble.Breakdance.WebApi/HttpClientHelpers.cs
+++ b/src/CloudNimble.Breakdance.WebApi/HttpClientHelpers.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 
-#if NET5_0_OR_GREATER
+#if NETCOREAPP3_1 || NET5_0_OR_GREATER
 namespace CloudNimble.Breakdance.AspNetCore
 #else
 namespace CloudNimble.Breakdance.WebApi

--- a/src/CloudNimble.Breakdance.WebApi/ODataConstants.cs
+++ b/src/CloudNimble.Breakdance.WebApi/ODataConstants.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+﻿#if NETCOREAPP3_1 || NET5_0_OR_GREATER
 namespace CloudNimble.Breakdance.AspNetCore
 #else
 namespace CloudNimble.Breakdance.WebApi

--- a/src/CloudNimble.Breakdance.WebApi/WebApiConstants.cs
+++ b/src/CloudNimble.Breakdance.WebApi/WebApiConstants.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+﻿#if NETCOREAPP3_1 || NET5_0_OR_GREATER
 namespace CloudNimble.Breakdance.AspNetCore
 #else
 namespace CloudNimble.Breakdance.WebApi


### PR DESCRIPTION
This update to Breakdance corrects some bugs in the Breakdance.Tools project and adds the ability for the tool to run within a Test project instead of from the root of a solution.  Additionally, this update brings in the HttpClientHelpers in Breakdance.WebApi to Breakdance.AspNetCore.