### PR TITLE
Add TestCacheDelegatingHandler

### DIFF
--- a/src/CloudNimble.Breakdance.Assemblies/Breakdance.Assemblies.csproj
+++ b/src/CloudNimble.Breakdance.Assemblies/Breakdance.Assemblies.csproj
@@ -71,6 +71,7 @@
     <PackageReference Include="System.Reflection" Version="[4.3.0, 6.0.0)" />
     <PackageReference Include="System.Reflection.Primitives" Version="[4.3.0, 6.0.0)" />
     <PackageReference Include="System.Threading.Tasks" Version="[4.3.0, 6.0.0)" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.0, 6.0.0)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -80,6 +81,9 @@
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>CloudNimble.Breakdance.AspNetCore, $(StrongNamePublicKey)</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>CloudNimble.Breakdance.Tests.Assemblies, $(StrongNamePublicKey)</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheDelegatingHandlerBase.cs
+++ b/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheDelegatingHandlerBase.cs
@@ -1,12 +1,7 @@
-﻿using Microsoft.Extensions.FileSystemGlobbing.Internal;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace CloudNimble.Breakdance.Assemblies.Http
 {

--- a/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheDelegatingHandlerBase.cs
+++ b/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheDelegatingHandlerBase.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.Extensions.FileSystemGlobbing.Internal;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace CloudNimble.Breakdance.Assemblies.Http
+{
+
+    /// <summary>
+    /// Base class for implementation of TestCache handlers for unit testing.
+    /// </summary>
+    public class TestCacheDelegatingHandlerBase : DelegatingHandler
+    {
+        #region Properties
+
+        /// <summary>
+        /// Stores the root folder for reading/writing static response files.
+        /// </summary>
+        public string ResponseFilesPath { get; private set; }
+
+        private static string InvalidCharacterPattern = @"[\/\?&:]";
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor overload for specifying the root folder path.
+        /// </summary>
+        /// <param name="responseFilesPath">Root folder path for storing static response files.</param>
+        public TestCacheDelegatingHandlerBase(string responseFilesPath)
+        {
+            ResponseFilesPath = responseFilesPath;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Parses the RequestUri in the <see cref="HttpRequestMessage"/> into a <see cref="Path"/>-safe string.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> to parse.</param>
+        /// <returns></returns>
+        internal static (string DirectoryPath, string FilePath) GetStaticFilePath(HttpRequestMessage request)
+        {
+            string directory;
+            string fileName;
+
+            var segments = request.RequestUri.Segments.Length;
+            var hasQuery = !string.IsNullOrEmpty(request.RequestUri.Query);
+
+            if (segments == 0)
+            {
+                // an invalid request was provided
+                throw new ArgumentException(nameof(request), "The specified HttpRequestMessage has an invalid RequestUri.");
+            }
+
+            if (segments == 1)
+            {
+                // return the full host as the directory with a root file
+                return (request.RequestUri.DnsSafeHost, "root");
+            }
+
+            // if the URI includes a query, we will use it as the filename instead of the last segment
+            if (hasQuery)
+            {
+                // extract the last segment as the file name and strip invalid characters
+                fileName = Regex.Replace(request.RequestUri.Query.Replace("%20", "_"), InvalidCharacterPattern, "");
+                directory = JoinSegments(request, segments - 1);
+            }
+            else if (request.RequestUri.Segments[segments - 1].StartsWith("$"))
+            {
+                // use the final segment as the fileName (e.g. $metadata, $top=10, $count, etc)
+                fileName = Regex.Replace(request.RequestUri.Segments[segments - 1].Replace("%20", "_"), InvalidCharacterPattern, "");
+
+                // directory may be empty if there are no other segments
+                if (segments > 2)
+                {
+                    directory = JoinSegments(request, segments - 2);
+                }
+                else
+                {
+                    directory = request.RequestUri.DnsSafeHost;
+                }
+            }
+            else
+            {
+                // if there is no query, the file name will always be "root"
+                fileName = "root";
+
+                // extract all the inside segments as the directory name
+                directory = JoinSegments(request, segments - 1);
+            }
+
+            // pre-pend the DNS-save host name and return the components in a tuple
+            return (directory, fileName);
+
+        }
+
+        /// <summary>
+        /// Joins the segments of the request together and returns the string as a path, prepended with the host name
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> to parse.</param>
+        /// <param name="index">Index to use whe joining segments.</param>
+        /// <returns></returns>
+        private static string JoinSegments(HttpRequestMessage request, int index)
+        {
+            var directory = Regex.Replace(string.Join("\\", request.RequestUri.Segments, 1, index).Replace("(", "\\(").Replace("%20", "_"), InvalidCharacterPattern, "");
+            return Path.Combine(request.RequestUri.DnsSafeHost, directory ?? "");
+        }
+
+    }
+}

--- a/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheReadDelegatingHandler.cs
+++ b/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheReadDelegatingHandler.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CloudNimble.Breakdance.Assemblies.Http
+{
+
+    /// <summary>
+    /// Handler for mocking the HttpResponse returned by an HttpRequest using a UTF-8 encoded file.
+    /// </summary>
+    public class TestCacheReadDelegatingHandler : TestCacheDelegatingHandlerBase
+    {
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor overload for specifying the root folder path.
+        /// </summary>
+        /// <param name="responseFilesPath">Root folder path for storing static response files.</param>
+        public TestCacheReadDelegatingHandler(string responseFilesPath) : base(responseFilesPath)
+        { }
+
+        #endregion
+
+        /// <summary>
+        /// This internal method is here just to allow the test projects to call the otherwise inaccessibile SendAsync() method
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> that is being intercepted by the <see cref="DelegatingHandler"/>.</param>
+        /// <returns></returns>
+        internal async Task<HttpResponseMessage> SendAsyncInternal(HttpRequestMessage request)
+        {
+            return await SendAsync(request, new CancellationToken()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Overrides the method in the base <see cref="DelegatingHandler"/> to create a custom <see cref="HttpResponseMessage"/>.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> that is being intercepted by the <see cref="DelegatingHandler"/>.</param>
+        /// <param name="cancellationToken">Token for cancelling the asynchronous request.</param>
+        /// <returns></returns>
+        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            // parse the URI into a content file path structure
+            var pathComponents = GetStaticFilePath(request);
+
+            // get the full path for the response file
+            var fullPath = Path.Combine(ResponseFilesPath, pathComponents.DirectoryPath, pathComponents.FilePath);
+
+            if (!File.Exists(fullPath))
+            {
+                throw new InvalidOperationException($"No test cache response file could be found at the path: {fullPath}.");
+            }
+
+#if NETCOREAPP3_1_OR_GREATER
+            var fileContent = await File.ReadAllTextAsync(fullPath, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+#else
+            var fileContent = File.ReadAllText(fullPath, Encoding.UTF8);
+#endif
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(fileContent)
+            };
+
+            var taskCompletionSource = new TaskCompletionSource<HttpResponseMessage>();
+            taskCompletionSource.SetResult(response);
+
+            return await taskCompletionSource.Task.ConfigureAwait(false);
+        }
+
+    }
+}

--- a/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheReadDelegatingHandler.cs
+++ b/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheReadDelegatingHandler.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheWriteDelegatingHandler.cs
+++ b/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheWriteDelegatingHandler.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;

--- a/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheWriteDelegatingHandler.cs
+++ b/src/CloudNimble.Breakdance.Assemblies/Http/TestCacheWriteDelegatingHandler.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CloudNimble.Breakdance.Assemblies.Http
+{
+
+    /// <summary>
+    /// Handler for mocking the HttpResponse returned by an HttpRequest using a UTF-8 encoded file.
+    /// </summary>
+    public class TestCacheWriteDelegatingHandler : TestCacheDelegatingHandlerBase
+    {
+        #region Constructors
+
+        /// <summary>
+        /// Constructor overload for specifying the root folder path.
+        /// </summary>
+        /// <param name="responseFilesPath">Root folder path for storing static response files.</param>
+        public TestCacheWriteDelegatingHandler(string responseFilesPath) : base(responseFilesPath)
+        { }
+
+        #endregion
+
+        /// <summary>
+        /// This internal method is here just to allow the test projects to call the otherwise inaccessibile SendAsync() method
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> that is being intercepted by the <see cref="DelegatingHandler"/>.</param>
+        /// <returns></returns>
+        internal async Task<HttpResponseMessage> SendAsyncInternal(HttpRequestMessage request)
+        {
+            return await SendAsync(request, new CancellationToken()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Overrides the method in the base <see cref="DelegatingHandler"/> to create a custom <see cref="HttpResponseMessage"/>.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> that is being intercepted by the <see cref="DelegatingHandler"/>.</param>
+        /// <param name="cancellationToken">Token for cancelling the asynchronous request.</param>
+        /// <returns></returns>
+        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            // allow the request to complete
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if (response is null)
+            {
+                // throw ??
+            }
+
+            // parse the URI into a content file path structure
+            var (DirectoryPath, FilePath) = GetStaticFilePath(request);
+
+            // make sure the folder exists to store the query file
+            var folderPath = Path.Combine(ResponseFilesPath, DirectoryPath);
+            Directory.CreateDirectory(folderPath);
+
+            // get the full path for the response file
+            var fullPath = Path.Combine(ResponseFilesPath, DirectoryPath, FilePath);
+
+            var fileContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+#if NETCOREAPP3_1_OR_GREATER
+            await File.WriteAllTextAsync(fullPath, fileContent, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+#else
+            File.WriteAllText(fullPath, fileContent, Encoding.UTF8);
+#endif
+
+            var taskCompletionSource = new TaskCompletionSource<HttpResponseMessage>();
+            taskCompletionSource.SetResult(response);
+
+            return await taskCompletionSource.Task.ConfigureAwait(false);
+        }
+    }
+}

--- a/src/CloudNimble.Breakdance.Tests.Assemblies/Breakdance.Tests.Assemblies.csproj
+++ b/src/CloudNimble.Breakdance.Tests.Assemblies/Breakdance.Tests.Assemblies.csproj
@@ -33,4 +33,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="ResponseFiles\" />
+  </ItemGroup>
+
 </Project>

--- a/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheDelegatingHandlerBaseTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheDelegatingHandlerBaseTests.cs
@@ -1,14 +1,9 @@
-﻿using CloudNimble.Breakdance.Assemblies;
-using CloudNimble.Breakdance.Assemblies.Http;
+﻿using CloudNimble.Breakdance.Assemblies.Http;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace CloudNimble.Breakdance.Tests.Assemblies.Http
 {

--- a/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheDelegatingHandlerBaseTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheDelegatingHandlerBaseTests.cs
@@ -1,0 +1,75 @@
+﻿using CloudNimble.Breakdance.Assemblies;
+using CloudNimble.Breakdance.Assemblies.Http;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CloudNimble.Breakdance.Tests.Assemblies.Http
+{
+
+    /// <summary>
+    /// Tests the functionality of the <see cref="StaticFileResponseHttpMessageHandler"/>.
+    /// </summary>
+    [TestClass]
+    public class TestCacheDelegatingHandlerBaseTests
+    {
+
+        /// <summary>
+        /// Root directory for storing response files.
+        /// </summary>
+        internal static string ResponseFilesPath = "..\\..\\..\\ResponseFiles";
+
+        internal static IEnumerable<object[]> GetPathsAndTestUris =>
+            new List<object[]>
+            {
+                new object[] { "services.odata.org", "root", "https://services.odata.org" },
+                new object[] { "services.odata.org", "$metadata", "https://services.odata.org/$metadata" },
+                new object[] { "services.odata.org\\Entity", "$filter=query", "https://services.odata.org/Entity?$filter=query" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People", "root", "https://services.odata.org/TripPinRESTierService/People" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People\\('russellwhyte')", "root", "https://services.odata.org/TripPinRESTierService/People('russellwhyte')" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\Airports\\('KSFO')\\Name", "root", "https://services.odata.org/TripPinRESTierService/Airports('KSFO')/Name" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\Airports\\('KSFO')\\Location\\Address", "root", "https://services.odata.org/TripPinRESTierService/Airports('KSFO')/Location/Address" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\Airports\\('KSFO')\\Name", "$value", "https://services.odata.org/TripPinRESTierService/Airports('KSFO')/Name/$value" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People\\('russellwhyte')\\Gender", "$value", "https://services.odata.org/TripPinRESTierService/People('russellwhyte')/Gender/$value" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\Airports\\('KSFO')\\Location", "root", "https://services.odata.org/TripPinRESTierService/Airports('KSFO')/Location" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People\\('russellwhyte')\\AddressInfo", "root", "https://services.odata.org/TripPinRESTierService/People('russellwhyte')/AddressInfo" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People", "$filter=FirstName_eq_'Scott'", "https://services.odata.org/TripPinRESTierService/People?$filter=FirstName eq 'Scott'" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\Airports", "$filter=contains(LocationAddress,_'San_Francisco')", "https://services.odata.org/TripPinRESTierService/Airports?$filter=contains(Location/Address, 'San Francisco')" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People", "$filter=Gender_eq_Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender'Female'", "https://services.odata.org/TripPinRESTierService/People?$filter=Gender eq Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender'Female'" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\Airports", "$select=Name,_IcaoCode", "https://services.odata.org/TripPinRESTierService/Airports?$select=Name, IcaoCode" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People\\('scottketchum')\\Trips", "$orderby=EndsAt_desc", "https://services.odata.org/TripPinRESTierService/People('scottketchum')/Trips?$orderby=EndsAt desc" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People", "$top=2", "https://services.odata.org/TripPinRESTierService/People?$top=2" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People", "$skip=18", "https://services.odata.org/TripPinRESTierService/People?$skip=18" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People", "$count", "https://services.odata.org/TripPinRESTierService/People/$count" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\Me\\Friends", "$filter=Friendsany(ffFirstName_eq_'Scott')", "https://services.odata.org/TripPinRESTierService/Me/Friends?$filter=Friends/any(f:f/FirstName eq 'Scott')" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People\\('keithpinckney')", "$expand=Trips", "https://services.odata.org/TripPinRESTierService/People('keithpinckney')?$expand=Trips" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People\\('russellwhyte')", "$expand=Trips($top=1)", "https://services.odata.org/TripPinRESTierService/People('russellwhyte')?$expand=Trips($top=1)" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People\\('russellwhyte')", "$expand=Trips($select=TripId,_Name)", "https://services.odata.org/TripPinRESTierService/People('russellwhyte')?$expand=Trips($select=TripId, Name)" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People\\('russellwhyte')", "$expand=Trips($filter=Name_eq_'Trip_in_US')", "https://services.odata.org/TripPinRESTierService/People('russellwhyte')?$expand=Trips($filter=Name eq 'Trip in US')" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\GetNearestAirport\\(lat_=_33,_lon_=_-118)", "root", "https://services.odata.org/TripPinRESTierService/GetNearestAirport(lat = 33, lon = -118)" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People\\('russellwhyte')\\Trips\\(0)\\Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople", "root", "https://services.odata.org/TripPinRESTierService/People('russellwhyte')/Trips(0)/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\ResetDataSource", "root", "https://services.odata.org/TripPinRESTierService/ResetDataSource" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\People\\('russellwhyte')\\Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip", "root", "https://services.odata.org/TripPinRESTierService/People('russellwhyte')/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\Airlines", "root", "https://services.odata.org/TripPinRESTierService/Airlines" },
+                new object[] { "services.odata.org\\TripPinRESTierService\\Airlines\\('AA')", "root", "https://services.odata.org/TripPinRESTierService/Airlines('AA')" },
+            };
+
+        [TestMethod]
+        [DynamicData(nameof(GetPathsAndTestUris))]
+        public void GetStaticFilePath_CanParse_Uris(string directoryPath, string fileName, string requestUri)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var (DirectoryPath, FilePath) = TestCacheDelegatingHandlerBase.GetStaticFilePath(request);
+            Path.GetFileName(FilePath).IndexOfAny(Path.GetInvalidFileNameChars()).Should().BeLessThan(0);
+            DirectoryPath.Should().Be(directoryPath);
+            FilePath.Should().Be(fileName);
+        }
+
+    }
+}

--- a/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheReadDelegatingHandlerTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheReadDelegatingHandlerTests.cs
@@ -1,17 +1,12 @@
-﻿using CloudNimble.Breakdance.Assemblies;
-using CloudNimble.Breakdance.Assemblies.Http;
+﻿using CloudNimble.Breakdance.Assemblies.Http;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Http;
-using Microsoft.AspNetCore.TestHost;
 using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace CloudNimble.Breakdance.Tests.Assemblies.Http
 {

--- a/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheReadDelegatingHandlerTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheReadDelegatingHandlerTests.cs
@@ -1,0 +1,63 @@
+﻿using CloudNimble.Breakdance.Assemblies;
+using CloudNimble.Breakdance.Assemblies.Http;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http;
+using Microsoft.AspNetCore.TestHost;
+using System.Net;
+
+namespace CloudNimble.Breakdance.Tests.Assemblies.Http
+{
+
+    /// <summary>
+    /// Tests the functionality of the <see cref="TestCacheReadDelegatingHandler"/>.
+    /// </summary>
+    [TestClass]
+    public class TestCacheReadDelegatingHandlerTests
+    {
+
+        #region Private Properties
+
+        /// <summary>
+        /// Root directory for storing response files.
+        /// </summary>
+        private static string ResponseFilesPath => TestCacheDelegatingHandlerBaseTests.ResponseFilesPath;
+
+        /// <summary>
+        /// Local reference to test data is needed here or MSTest will choke.
+        /// </summary>
+        private static IEnumerable<object[]> GetPathsAndTestUris => TestCacheDelegatingHandlerBaseTests.GetPathsAndTestUris;
+
+        #endregion
+
+        [TestMethod]
+        [DynamicData(nameof(GetPathsAndTestUris))]
+        public async Task TestCacheReadDelegatingHandler_CanReadFile(string directoryPath, string fileName, string requestUri)
+        {
+            var handler = new TestCacheReadDelegatingHandler(ResponseFilesPath);
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var response = await handler.SendAsyncInternal(request);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var content = await response.Content.ReadAsStringAsync();
+            content.Should().NotBeNullOrEmpty();
+        }
+
+        [TestMethod]
+        public void TestCacheReadDelegatingHandler_ThrowsException_OnFileMissing()
+        {
+            File.Exists(Path.Combine(ResponseFilesPath, "services.odata.org", "missing-testcache-file")).Should().BeFalse();
+            var handler = new TestCacheReadDelegatingHandler(ResponseFilesPath);
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://services.odata.org/missing-testcache-file");
+            Action act = () => handler.SendAsyncInternal(request).GetAwaiter().GetResult();
+            act.Should().Throw<InvalidOperationException>().WithMessage("No test cache response file could be found at the path: *");
+        }
+
+    }
+}

--- a/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheWriteDelegatingHandlerTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheWriteDelegatingHandlerTests.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using CloudNimble.Breakdance.Assemblies.Http;
+using FluentAssertions;
+using System.Threading;
+using System.IO;
+
+namespace CloudNimble.Breakdance.Tests.Assemblies.Http
+{
+
+    /// <summary>
+    /// Tests the functionality of the <see cref="TestCacheWriteDelegatingHandler"/>.
+    /// </summary>
+    [TestClass]
+    public class TestCacheWriteDelegatingHandlerTests
+    {
+
+        #region Private Properties
+
+        /// <summary>
+        /// Root directory for storing response files.
+        /// </summary>
+        private static string ResponseFilesPath => TestCacheDelegatingHandlerBaseTests.ResponseFilesPath;
+
+        /// <summary>
+        /// Local reference to test data is needed here or MSTest will choke.
+        /// </summary>
+        private static IEnumerable<object[]> GetPathsAndTestUris => TestCacheDelegatingHandlerBaseTests.GetPathsAndTestUris;
+
+        #endregion
+
+        [TestMethod]
+        [DynamicData(nameof(GetPathsAndTestUris))]
+        public async Task TestCacheWriteDelegatingHandler_CanWriteFile(string directoryPath, string fileName, string requestUri)
+        {
+            var handler = new TestCacheWriteDelegatingHandler(ResponseFilesPath);
+            handler.InnerHandler = new FakeHttpResponseHandler();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var response = await handler.SendAsyncInternal(request);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var content = await response.Content.ReadAsStringAsync();
+            content.Should().NotBeNullOrEmpty();
+
+            File.Exists(Path.Combine(ResponseFilesPath, directoryPath, fileName)).Should().BeTrue();
+        }
+
+        private class FakeHttpResponseHandler : DelegatingHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
+                response.Content = new StringContent("{ }", Encoding.UTF8);
+                return Task.FromResult(response);
+            }
+        }
+
+    }
+}

--- a/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheWriteDelegatingHandlerTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.Assemblies/Http/TestCacheWriteDelegatingHandlerTests.cs
@@ -1,14 +1,13 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-using CloudNimble.Breakdance.Assemblies.Http;
+﻿using CloudNimble.Breakdance.Assemblies.Http;
 using FluentAssertions;
-using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace CloudNimble.Breakdance.Tests.Assemblies.Http
 {

--- a/src/CloudNimble.Breakdance.Tests.Assemblies/PublicApiHelpersTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.Assemblies/PublicApiHelpersTests.cs
@@ -25,7 +25,8 @@ namespace CloudNimble.Breakdance.Tests.Assemblies
         {
             var definitions = PublicApiHelpers.GenerateTypeDefinitionsForAssembly("CloudNimble.Breakdance.Assemblies.dll");
             definitions.Should().NotBeNullOrEmpty();
-            definitions.Should().HaveCount(16);
+            // JHC: updated this to add the 3 new classes for the TestCacheDelegatingHandler
+            definitions.Should().HaveCount(19);
         }
 
         [TestMethod]


### PR DESCRIPTION
Added a new feature to allow capture of HttpResponseMessages into files for caching and use in testing as automated response delegation.