### PR TITLE
Move GetService<T> and GetServices<T> implementation to base class to extend their reach.

### DIFF
--- a/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreBreakdanceTestBase.cs
+++ b/src/CloudNimble.Breakdance.AspNetCore/AspNetCoreBreakdanceTestBase.cs
@@ -66,12 +66,10 @@ namespace CloudNimble.Breakdance.AspNetCore
         /// </remarks>
         public void AddMinimalMvc(Action<MvcOptions> options = default, Action<IApplicationBuilder> app = default)
         {
-            TestHostBuilder.ConfigureServices(services =>
-            {
+            TestHostBuilder.ConfigureServices(services => {
                 services.AddMvcCore(options ?? (mvcOptions => { }));
             })
-            .Configure(app ?? ((IApplicationBuilder appBuilder) =>
-            {
+            .Configure(app ?? ((IApplicationBuilder appBuilder) => {
                 appBuilder.UseRouting();
                 appBuilder.UseEndpoints(endpoints => endpoints.MapControllers());
             }));
@@ -93,12 +91,10 @@ namespace CloudNimble.Breakdance.AspNetCore
         /// </remarks>
         public void AddApis(Action<MvcOptions> options = default, Action<IApplicationBuilder> app = default)
         {
-            TestHostBuilder.ConfigureServices(services =>
-            {
+            TestHostBuilder.ConfigureServices(services => {
                 services.AddControllers(options ?? (mvcoptions => { }));
             })
-            .Configure(app ?? ((IApplicationBuilder appBuilder) =>
-            {
+            .Configure(app ?? ((IApplicationBuilder appBuilder) => {
                 appBuilder.UseRouting();
                 appBuilder.UseEndpoints(endpoints => endpoints.MapControllers());
             }));
@@ -123,12 +119,10 @@ namespace CloudNimble.Breakdance.AspNetCore
         /// </remarks>
         public void AddViews(Action<MvcOptions> options = default, Action<IApplicationBuilder> app = default)
         {
-            TestHostBuilder.ConfigureServices(services =>
-            {
+            TestHostBuilder.ConfigureServices(services => {
                 services.AddControllersWithViews(options ?? (mvcOptions => { }));
             })
-            .Configure(app ?? ((IApplicationBuilder appBuilder) =>
-            {
+            .Configure(app ?? ((IApplicationBuilder appBuilder) => {
                 appBuilder.UseRouting();
                 appBuilder.UseEndpoints(endpoints => endpoints.MapControllers());
             }));
@@ -147,12 +141,10 @@ namespace CloudNimble.Breakdance.AspNetCore
         /// </remarks>
         public void AddRazorPages(Action<RazorPagesOptions> options = default, Action<IApplicationBuilder> app = default)
         {
-            TestHostBuilder.ConfigureServices(services =>
-            {
+            TestHostBuilder.ConfigureServices(services => {
                 services.AddRazorPages(options ?? (razorOptions => { }));
             })
-            .Configure(app ?? ((IApplicationBuilder appBuilder) =>
-            {
+            .Configure(app ?? ((IApplicationBuilder appBuilder) => {
                 appBuilder.UseRouting();
                 appBuilder.UseEndpoints(endpoints => endpoints.MapControllers());
             }));
@@ -197,14 +189,14 @@ namespace CloudNimble.Breakdance.AspNetCore
         /// </summary>
         /// <typeparam name="T">The type of service object to get.</typeparam>
         /// <returns>A service object of type <typeparamref name="T"/>.</returns>
-        public T GetService<T>() where T : class => TestServer?.Services.GetService<T>();
+        public override T GetService<T>() where T : class => TestServer?.Services.GetService<T>() ?? base.GetService<T>();
 
         /// <summary>
         /// Get an enumeration of services of type <typeparamref name="T"/> from the System.IServiceProvider.
         /// </summary>
         /// <typeparam name="T">The type of service object to get.</typeparam>
         /// <returns>An enumeration of services of type <typeparamref name="T"/>.</returns>
-        public IEnumerable<T> GetServices<T>() where T : class => TestServer?.Services.GetServices<T>();
+        public override IEnumerable<T> GetServices<T>() where T : class => TestServer?.Services.GetServices<T>() ?? base.GetServices<T>();
 
         /// <summary>
         /// Method used by test assemblies to setup the environment.
@@ -219,8 +211,6 @@ namespace CloudNimble.Breakdance.AspNetCore
             base.AssemblySetup();
             EnsureTestServer();
         }
-
-
 
         /// <summary>
         /// Method used by test classes to setup the environment.

--- a/src/CloudNimble.Breakdance.Assemblies/BreakdanceTestBase.cs
+++ b/src/CloudNimble.Breakdance.Assemblies/BreakdanceTestBase.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.Hosting;
 using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace CloudNimble.Breakdance.Assemblies
 {
@@ -99,6 +101,20 @@ namespace CloudNimble.Breakdance.Assemblies
         public virtual void TestTearDown()
         {
         }
+
+        /// <summary>
+        /// Get service of type <typeparamref name="T"/> from the System.IServiceProvider.
+        /// </summary>
+        /// <typeparam name="T">The type of service object to get.</typeparam>
+        /// <returns>A service object of type <typeparamref name="T"/>.</returns>
+        public virtual T GetService<T>() where T : class => TestHost?.Services.GetService<T>();
+
+        /// <summary>
+        /// Get an enumeration of services of type <typeparamref name="T"/> from the System.IServiceProvider.
+        /// </summary>
+        /// <typeparam name="T">The type of service object to get.</typeparam>
+        /// <returns>An enumeration of services of type <typeparamref name="T"/>.</returns>
+        public virtual IEnumerable<T> GetServices<T>() where T : class => TestHost?.Services.GetServices<T>();
 
         #endregion
 

--- a/src/CloudNimble.Breakdance.Blazor/BlazorBreakdanceTestBase.cs
+++ b/src/CloudNimble.Breakdance.Blazor/BlazorBreakdanceTestBase.cs
@@ -40,14 +40,14 @@ namespace CloudNimble.Breakdance.Blazor
         /// </summary>
         /// <typeparam name="T">The type of service object to get.</typeparam>
         /// <returns>A service object of type <typeparamref name="T"/>.</returns>
-        public T GetService<T>() where T : class => BUnitTestContext?.Services.GetService<T>() ?? TestHost?.Services.GetService<T>();
+        public override T GetService<T>() where T : class => BUnitTestContext?.Services.GetService<T>() ?? base.GetService<T>();
 
         /// <summary>
         /// Get an enumeration of services of type <typeparamref name="T"/> from the System.IServiceProvider.
         /// </summary>
         /// <typeparam name="T">The type of service object to get.</typeparam>
         /// <returns>An enumeration of services of type <typeparamref name="T"/>.</returns>
-        public IEnumerable<T> GetServices<T>() where T : class  => BUnitTestContext?.Services.GetServices<T>() ?? TestHost?.Services.GetServices<T>();
+        public override IEnumerable<T> GetServices<T>() where T : class  => BUnitTestContext?.Services.GetServices<T>() ?? base.GetServices<T>();
 
         /// <summary>
         /// Properly instantiates the <see cref="BUnitTestContext"/> and if <see cref="RegisterServices"/> is not null, properly registers additional services with the context.


### PR DESCRIPTION
Implemented GetService<T> and GetServices<T> as virtual methods in BreakdanceTestBase.  Marked the appropriate methods in AspNetCore and Blazor as override.