### PR TITLE
Handle multiple registered handlers for same methodName

### DIFF
--- a/src/CloudNimble.Breakdance.AspNetCore.SignalR/InvocationHandle.cs
+++ b/src/CloudNimble.Breakdance.AspNetCore.SignalR/InvocationHandle.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CloudNimble.Breakdance.AspNetCore.SignalR
+{
+    /// <summary>
+    /// Record for the types, handlers and the invocation state of a HubConnection handler.
+    /// </summary>
+    /// <param name="ParameterTypes"></param>
+    /// <param name="Handler"></param>
+    /// <param name="State"></param>
+    public record InvocationHandle(Type[] ParameterTypes, Func<object[], object, Task> Handler, object State);
+}

--- a/src/CloudNimble.Breakdance.Tests.AspNetCore.SignalR/TestableHubConnectionTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.AspNetCore.SignalR/TestableHubConnectionTests.cs
@@ -52,7 +52,7 @@ namespace CloudNimble.Breakdance.Tests.AspNetCore.SignalR
         }
 
         /// <summary>
-        /// Tests that the <see cref="TestableNamedHubConnection"/> can register two handlers for same method.
+        /// Tests that the <see cref="TestableNamedHubConnection"/> can register two handlers for same methodName.
         /// </summary>
         [TestMethod]
         public async Task CanRegisterHandlers()
@@ -62,7 +62,6 @@ namespace CloudNimble.Breakdance.Tests.AspNetCore.SignalR
             await hubConnection.StartAsync();
 
             hubConnection.On("HubMethod", () => { });
-
             hubConnection.On<bool>("HubMethod", (b) => { });
 
             var testabelHubConnection = (TestableNamedHubConnection)hubConnection;
@@ -147,7 +146,7 @@ namespace CloudNimble.Breakdance.Tests.AspNetCore.SignalR
         }
 
         /// <summary>
-        /// Tests that the <see cref="TestableNamedHubConnection"/> can invoke all handlera that had been registered for a methodName.
+        /// Tests that the <see cref="TestableNamedHubConnection"/> can invoke all handlers that had been registered for a methodName.
         /// </summary>
         [TestMethod]
         public async Task CanInvokeHandlers()


### PR DESCRIPTION
The base HubConnection can handle multiple handlers for the same methodName, but we couldn't before.

This PR adds that possibility and adds tests for that.