### PR TITLE
Add capability to get scoped services from BreakdanceTestBase.

### DIFF
--- a/src/CloudNimble.Breakdance.Assemblies/BreakdanceTestBase.cs
+++ b/src/CloudNimble.Breakdance.Assemblies/BreakdanceTestBase.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
+using CloudNimble.EasyAF.Core;
 
 namespace CloudNimble.Breakdance.Assemblies
 {
@@ -24,6 +25,11 @@ namespace CloudNimble.Breakdance.Assemblies
         /// The <see cref="IHostBuilder"/> instance used to configure the test host.
         /// </summary>
         public IHostBuilder TestHostBuilder { get; internal set; }
+
+        /// <summary>
+        /// Provides a default <see cref="IServiceScope"/> implementation to contain scoped services.
+        /// </summary>
+        public IServiceScope DefaultScope { get; set; }
 
         #endregion
 
@@ -115,6 +121,28 @@ namespace CloudNimble.Breakdance.Assemblies
         /// <typeparam name="T">The type of service object to get.</typeparam>
         /// <returns>An enumeration of services of type <typeparamref name="T"/>.</returns>
         public virtual IEnumerable<T> GetServices<T>() where T : class => TestHost?.Services.GetServices<T>();
+
+        /// <summary>
+        /// Get the requested service from the specified <see cref="IServiceScope"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public T GetScopedService<T>(IServiceScope scope) where T : class
+        {
+            Ensure.ArgumentNotNull(scope, nameof(scope));
+            return scope.ServiceProvider.GetRequiredService<T>();
+        }
+
+        /// <summary>
+        /// Get the requested service from the default <see cref="IServiceScope"/> provided by Breakdance.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public T GetScopedService<T>() where T : class
+        {
+            DefaultScope ??= TestHost.Services.CreateScope();
+            return GetScopedService<T>(DefaultScope);
+        }
 
         #endregion
 

--- a/src/CloudNimble.Breakdance.Tests.Assemblies/BreakdanceTestBaseTests.cs
+++ b/src/CloudNimble.Breakdance.Tests.Assemblies/BreakdanceTestBaseTests.cs
@@ -116,6 +116,28 @@ namespace CloudNimble.Breakdance.Tests.Assemblies
             configuration.GetValue<string>("ApplicationName").Should().Be("Alpha Tests");
         }
 
+        [TestMethod]
+        public void BreakdanceTestBase_GetScopedService_DefaultScope()
+        {
+            var testBase = new TestBase();
+            testBase.TestHostBuilder.ConfigureServices((services) => services.AddScoped(_ => new DummyScopedService()));
+            testBase.TestSetup();
+            testBase.TestHost.Services.Should().NotBeNull();
+            testBase.GetScopedService<DummyScopedService>().Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void BreakdanceTestBase_GetScopedService_ExistingScope()
+        {
+            var testBase = new TestBase();
+            testBase.TestHostBuilder.ConfigureServices((services) => services.AddScoped(_ => new DummyScopedService()));
+            testBase.TestSetup();
+            testBase.TestHost.Services.Should().NotBeNull();
+            var manualScope = testBase.TestHost.Services.CreateScope();
+            manualScope.Should().NotBeNull();
+            testBase.GetScopedService<DummyScopedService>(manualScope).Should().NotBeNull();
+        }
+
     }
 
     /// <summary>
@@ -123,6 +145,14 @@ namespace CloudNimble.Breakdance.Tests.Assemblies
     /// </summary>
     internal class TestBase : BreakdanceTestBase
     {
+    }
+
+    /// <summary>
+    /// A fake class for testing methods that use the <see cref="IServiceScope"/>.
+    /// </summary>
+    internal class DummyScopedService
+    {
+
     }
 
 }


### PR DESCRIPTION
When testing using build configuration other than DEBUG, some services require a scope.  GetService<T> in BreakdanceTestBase cannot return a useable instance of these services.  This update adds in IServiceScope to the class and will use it as a container for scoped services.  The change then adds the new GetScopedService<T> and GetScopedServices<T> methods to interact with this container. 